### PR TITLE
Optionally, save door state(s) to a file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: pip
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "10:00"
+  open-pull-requests-limit: 10

--- a/bin/pi_garage_alert.py
+++ b/bin/pi_garage_alert.py
@@ -691,6 +691,12 @@ def format_duration(duration_sec):
 
     return ret
 
+def persist_door_state(name, state):
+    """If configured, save the current door state to a file"""
+    if cfg.DOOR_STATE_FILENAME:
+        with open(cfg.DOOR_STATE_FILENAME, "w") as state_file:
+            state_file.write("%s|%s" % (name, state.upper()))
+
 
 ##############################################################################
 # Main functionality
@@ -775,6 +781,9 @@ class PiGarageAlert(object):
                         door_states[name] = state
                         time_of_last_state_change[name] = time.time()
                         self.logger.info("State of \"%s\" changed to %s after %.0f sec", name, state, time_in_state)
+
+                        # Write the door state to a file, if configured
+                        persist_door_state(name, state)
 
                         # Reset alert when door changes state
                         if alert_states[name] > 0:

--- a/etc/pi_garage_alert_config.py
+++ b/etc/pi_garage_alert_config.py
@@ -41,6 +41,16 @@ GARAGE_DOORS = [
     }
 ]
 
+# A valid file-path here will enable writing the door state(s) into it.
+# This can be read, for example, by other app/services running on the same pi
+# The contents will look something like:
+'''
+Garage Door 1|OPEN
+Example Garage Door|CLOSED
+'''
+# To use, set value to something like "/usr/local/etc/pi_garage_alert_door_state"
+DOOR_STATE_FILENAME = ""
+
 # All messages will be logged to stdout and this file
 LOG_FILENAME = "/var/log/pi_garage_alert.log"
 


### PR DESCRIPTION
First of all, thank you @rllynch for the beautiful write-ups and the really well-factored, readable code that "just worked". 👍 

This change can be really useful, if there are other apps/services running on the same Raspberry PI that needs to peek into the current door state.

I am using this in conjunction with another (similarly awesome) [Node.js app](https://github.com/chasechou/node-garagepi) and [a detailed write-up](https://coderwall.com/p/jsd5mw/raspberry-pi-garage-door-opener-with-garagepi) - thanks to you too, @chasechou

With the current door state now being immediately available via a shared file, [this little hard-coded tech-debt](https://github.com/chasechou/node-garagepi/blob/master/garagepi.js#L30) on that app can be closed out. 🙂 